### PR TITLE
chore: rm unused dep jsnetworkx

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "core-js": "^3.9.1",
         "debug": "^4.3.1",
         "husky": "^4.3.8",
-        "jsnetworkx": "^0.3.4",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -3848,20 +3847,6 @@
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
-    },
-    "node_modules/babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-      "dependencies": {
-        "core-js": "^1.0.0"
-      }
-    },
-    "node_modules/babel-runtime/node_modules/core-js": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-      "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
-      "deprecated": "core-js@<3.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js."
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -10023,22 +10008,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/jsnetworkx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/jsnetworkx/-/jsnetworkx-0.3.4.tgz",
-      "integrity": "sha1-HAAl35QgjOtcxZ5lj5qb9f709vQ=",
-      "dependencies": {
-        "babel-runtime": "^5",
-        "lodash": "^3.3.1",
-        "through": "^2.3.6",
-        "tiny-sprintf": "^0.3.0"
-      }
-    },
-    "node_modules/jsnetworkx/node_modules/lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-    },
     "node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -13708,11 +13677,6 @@
       "engines": {
         "node": ">= 6"
       }
-    },
-    "node_modules/tiny-sprintf": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-sprintf/-/tiny-sprintf-0.3.0.tgz",
-      "integrity": "sha1-QnL9XB0vkoByI/wW1yj98wWVoz4="
     },
     "node_modules/tmp": {
       "version": "0.0.33",
@@ -18170,21 +18134,6 @@
       "requires": {
         "babel-plugin-jest-hoist": "^26.6.2",
         "babel-preset-current-node-syntax": "^1.0.0"
-      }
-    },
-    "babel-runtime": {
-      "version": "5.8.38",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.38.tgz",
-      "integrity": "sha1-HAsC62MxL18If/IEUIJ7QlydTBk=",
-      "requires": {
-        "core-js": "^1.0.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
       }
     },
     "balanced-match": {
@@ -22870,24 +22819,6 @@
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
       "dev": true
     },
-    "jsnetworkx": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/jsnetworkx/-/jsnetworkx-0.3.4.tgz",
-      "integrity": "sha1-HAAl35QgjOtcxZ5lj5qb9f709vQ=",
-      "requires": {
-        "babel-runtime": "^5",
-        "lodash": "^3.3.1",
-        "through": "^2.3.6",
-        "tiny-sprintf": "^0.3.0"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        }
-      }
-    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -25735,11 +25666,6 @@
           }
         }
       }
-    },
-    "tiny-sprintf": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/tiny-sprintf/-/tiny-sprintf-0.3.0.tgz",
-      "integrity": "sha1-QnL9XB0vkoByI/wW1yj98wWVoz4="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "core-js": "^3.9.1",
     "debug": "^4.3.1",
     "husky": "^4.3.8",
-    "jsnetworkx": "^0.3.4",
     "lodash": "^4.17.21"
   },
   "husky": {


### PR DESCRIPTION
It appears the dependency jsnetworkx isn't being used anywhere in this package, and it's introducing some warnings due to having outdated sub-dependencies. This pull request removes jsnetworkx.