### PR TITLE
fix wrong order of entities being parsed in metakg cnstruction

### DIFF
--- a/src/operations_builder/sync_operations_builder_with_reasoner.ts
+++ b/src/operations_builder/sync_operations_builder_with_reasoner.ts
@@ -38,10 +38,12 @@ export default class SyncOperationsBuilderWithReasoner extends BaseOperationsBui
     if (!("predicates" in metadata)) {
       return ops;
     }
-    Object.keys(metadata.predicates).map((sbj) => {
-      Object.keys(metadata.predicates[sbj]).map((obj) => {
-        if (Array.isArray(metadata.predicates[sbj][obj])) {
-          metadata.predicates[sbj][obj].map((pred) => {
+    //predicates are store as OBJ:{SUBJ:[predicates]}
+    //parses each layer accordingly
+    Object.keys(metadata.predicates).map((obj) => {
+      Object.keys(metadata.predicates[obj]).map((sbj) => {
+        if (Array.isArray(metadata.predicates[obj][sbj])) {
+          metadata.predicates[obj][sbj].map((pred) => {
             ops.push({
               association: {
                 input_type: this.removeBioLinkPrefix(sbj),


### PR DESCRIPTION
MetaKG construction is creating operations with object/subject in the wrong order going against the pattern that they are stored in the file being read. This PR fixes that order and correctly gets results from previously not working queries.