### PR TITLE
Fix #208: Update edge attributes

### DIFF
--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -36,6 +36,16 @@ export default class API implements APIClass {
     return this.smartapiDoc.info.title;
   }
 
+  private fetchXTranslatorInforesCurie(): string | undefined {
+    if (!("info" in this.smartapiDoc)) {
+      return undefined;
+    }
+    if (!("x-translator" in this.smartapiDoc.info)) {
+      return undefined;
+    }
+    return this.smartapiDoc.info["x-translator"]["infores-curie"];
+  }
+
   private fetchXTranslatorComponent(): string | undefined {
     if (!("info" in this.smartapiDoc)) {
       return undefined;
@@ -97,6 +107,7 @@ export default class API implements APIClass {
       "x-translator": {
         component: this.fetchXTranslatorComponent(),
         team: this.fetchXTranslatorTeam(),
+        "infores-curie": this.fetchXTranslatorInforesCurie() 
       },
       smartapi: {
         id: this.smartapiDoc._id,

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,6 +1,7 @@
 export interface XTranslatorObject {
   component: string;
   team: string[];
+  "infores-curie"?: string;
 }
 
 interface SmartAIPInfoObject {


### PR DESCRIPTION
Related to https://github.com/biothings/BioThings_Explorer_TRAPI/issues/208. Merge together with https://github.com/biothings/bte_trapi_query_graph_handler/pull/39.

Add `infores-curie` to the `x-translator` fields that smartapi-kg reads in. This is used because we want to replace the api name in the edge attributes with the infores curie for that data source.