### PR TITLE
Add support for templating-related operation annotations

### DIFF
--- a/src/parser/query_operation.ts
+++ b/src/parser/query_operation.ts
@@ -7,19 +7,29 @@ import {
 export default class QueryOperationObject implements QueryOperationInterface {
   private _params: XBTEParametersObject;
   private _requestBody: object;
+  private _requestBodyType: string;
   private _supportBatch: boolean;
+  private _useTemplating: boolean;
   private _inputSeparator: string;
   private _path: string;
   private _method: string;
   private _server: string;
   private _tags: string[];
   private _pathParams: string[];
+  private _templateInputs: object;
 
   set xBTEKGSOperation(newOp: XBTEKGSOperationObject) {
     this._params = newOp.parameters;
     this._requestBody = newOp.requestBody;
+    this._requestBodyType = newOp.requestBodyType;
     this._supportBatch = newOp.supportBatch;
+    this._useTemplating = newOp.useTemplating;
     this._inputSeparator = newOp.inputSeparator;
+    this._templateInputs = newOp.templateInputs;
+  }
+
+  get templateInputs(): object {
+    return this._templateInputs;
   }
 
   get params(): XBTEParametersObject {
@@ -30,8 +40,16 @@ export default class QueryOperationObject implements QueryOperationInterface {
     return this._requestBody;
   }
 
+  get requestBodyType(): string {
+    return this._requestBodyType;
+  }
+
   get supportBatch(): boolean {
     return this._supportBatch;
+  }
+
+  get useTemplating(): boolean {
+    return this._useTemplating;
   }
 
   get inputSeparator(): string {

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -113,10 +113,13 @@ export interface XBTEKGSOperationObject {
   source?: string;
   parameters?: XBTEParametersObject;
   requestBody?: any;
+  requestBodyType?: string;
   supportBatch?: boolean;
+  useTemplating?: boolean;
   inputSeparator?: string;
   response_mapping?: SmartAPIReferenceObject;
   responseMapping?: SmartAPIReferenceObject;
+  templateInputs?: object;
 }
 
 export interface SmartAPISpec {


### PR DESCRIPTION
This PR allows for additional query operation properties to be used by templating as implemented in biothings/call-apis.js#31.

Additional properties:
`useTemplating: true | false` Signals to use the template query builder.
`requestBodyType: string` If set to `'object'`, requestBody.body is parsed as JSON after templates are applied.
`templateInputs: object` An object containing any static inputs to be used by templates.